### PR TITLE
feat(bytestring): support `::string` type in construction patterns

### DIFF
--- a/bytestring/bytepattern.ml
+++ b/bytestring/bytepattern.ml
@@ -297,7 +297,7 @@ Trailing commas are supported, but a single comma is not a valid bytestring patt
 
 Valid sizes are:
 
-  %s      - match on the entire literal string
+  %s      - match on the literal string
   %s       - match on the entire string
   %s - match `expr` bytes
   %s        - match on 1 UTF-8 grapheme
@@ -307,7 +307,7 @@ Valid sizes are:
 
 For example:
 
-  hello::string      – use all of `hello` as a literal string
+  hello::string      – use all of `hello` as a string
   hello::bytes       – use all of `hello` as a byte string
   hello::bytes(len)  – use `len` bytes from `hello`
   hello::bits(len)   – use len bits of `hello` (128 bytes)
@@ -315,7 +315,7 @@ For example:
   hello::7           – use 8 bits of `hello`
 |}
              (error "Invalid size %S for %S" (Lexer.to_string tokens) name)
-             (keyword "%s" "string") (keyword "%s" "bytes")
+             (keyword "%s" "bytes") (keyword "%s" "string")
              (keyword "%s" "bytes(expr)")
              (keyword "%s" "utf8")
              (keyword "%s" "utf8(expr)")

--- a/bytestring/bytepattern.ml
+++ b/bytestring/bytepattern.ml
@@ -297,7 +297,7 @@ Trailing commas are supported, but a single comma is not a valid bytestring patt
 
 Valid sizes are:
 
-  %s      - match on the entire string literal
+  %s      - match on the entire literal string
   %s       - match on the entire string
   %s - match `expr` bytes
   %s        - match on 1 UTF-8 grapheme

--- a/bytestring/bytepattern.ml
+++ b/bytestring/bytepattern.ml
@@ -298,8 +298,8 @@ Trailing commas are supported, but a single comma is not a valid bytestring patt
 
 Valid sizes are:
 
-  %s      - match on the literal string
   %s       - match on the entire string
+  %s      - match on the literal string
   %s - match `expr` bytes
   %s        - match on 1 UTF-8 grapheme
   %s  - match `expr` UTF-8 graphemes

--- a/bytestring/bytepattern.ml
+++ b/bytestring/bytepattern.ml
@@ -502,7 +502,7 @@ For example:
 
 Valid sizes for string literals are:
 
-  %s      - match on the entire string literal
+  %s      - match on the entire string
   %s       - match on the entire string
   %s - match `expr` bytes
   %s        - match on 1 UTF-8 grapheme

--- a/bytestring/bytepattern_test.ml
+++ b/bytestring/bytepattern_test.ml
@@ -154,7 +154,7 @@ let () =
   test "all::8" [ Bind { name = "all"; size = Fixed_bits 8 } ];
   test "all::1024" [ Bind { name = "all"; size = Fixed_bits 1024 } ];
   test "all::utf8" [ Bind { name = "all"; size = Utf8 } ];
-  test "all::string" [ Bind { name = "all"; size = String_literal } ];
+  test "all::string" [ Bind { name = "all"; size = Rest_as_string } ];
   test "all::bytes" [ Bind { name = "all"; size = Rest } ];
   test "all::bytes(10)" [ Bind { name = "all"; size = Dynamic_bytes (int 10) } ];
   test "all::bytes(foo ())"
@@ -173,7 +173,7 @@ let () =
   test {|"rush\r\n"::bytes|}
     [ Expect { value = String "rush\r\n"; size = Rest } ];
   test {|"rush"::string|}
-    [ Expect { value = String "rush"; size = String_literal } ];
+    [ Expect { value = String "rush"; size = Rest_as_string } ];
   test {|"rush"::utf8|} [ Expect { value = String "rush"; size = Utf8 } ];
   test "len::8, body::bytes(len)"
     [
@@ -244,7 +244,7 @@ let () =
   test "all::string"
     [
       Create_transient "_trns";
-      Add_string_literal { src = "all" };
+      Add_rest_as_string { src = "all" };
       Commit_transient "_trns";
     ];
   test "all::bytes" [ Bypass "all" ];
@@ -507,7 +507,7 @@ let () =
   test "all::string"
     [
       Create_iterator "_data_src";
-      Bind_string_literal { src = "all"; iter = "_data_src" };
+      Bind_rest_as_string { src = "all"; iter = "_data_src" };
       Empty "_data_src";
     ];
   test "all::bytes" [ Bypass { src = "_data_src"; name = "all" } ];
@@ -648,7 +648,7 @@ let () =
   test {| all::string |}
     [%expr
       let _data_src = Bytestring.to_iter _data_src in
-      let all = Bytestring.Iter.string_literal _data_src in
+      let all = Bytestring.Iter.rest_as_string _data_src in
       Bytestring.Iter.expect_empty _data_src;
       ()];
   test {| all::bytes |}
@@ -1099,7 +1099,7 @@ let () =
       Try_run
         ( [
             Create_iterator "_data_src";
-            Bind_string_literal { src = "hello"; iter = "_data_src" };
+            Bind_rest_as_string { src = "hello"; iter = "_data_src" };
             Empty "_data_src";
           ],
           (None, id "test_7_body_0") );
@@ -1356,7 +1356,7 @@ let () =
     [%expr
       (fun _data_src ->
         let _data_src = Bytestring.to_iter _data_src in
-        let hello = Bytestring.Iter.string_literal _data_src in
+        let hello = Bytestring.Iter.rest_as_string _data_src in
         Bytestring.Iter.expect_empty _data_src;
         test_7_body_0)
         data];

--- a/bytestring/bytestring.ml
+++ b/bytestring/bytestring.ml
@@ -440,6 +440,12 @@ module Iter = struct
     t.length <- 0;
     rest
 
+  let string_literal t =
+    let str = t.bytes |> Seq.map Char.chr |> String.of_seq in
+    t.bytes <- Seq.empty;
+    t.length <- 0;
+    str
+
   let expect_bytes _bytes _t = ()
   let expect_literal_int _t ?size:_ _bit = ()
 

--- a/bytestring/bytestring.ml
+++ b/bytestring/bytestring.ml
@@ -440,7 +440,7 @@ module Iter = struct
     t.length <- 0;
     rest
 
-  let string_literal t =
+  let rest_as_string t =
     let str = t.bytes |> Seq.map Char.chr |> String.of_seq in
     t.bytes <- Seq.empty;
     t.length <- 0;

--- a/bytestring/bytestring.mli
+++ b/bytestring/bytestring.mli
@@ -42,6 +42,7 @@ module Iter : sig
   val next_utf8 : t -> bytestring
   val next_utf8_seq : len:int -> t -> bytestring
   val rest : t -> bytestring
+  val string_literal : t -> string
   val expect_empty : t -> unit
   val expect_bits : t -> int -> unit
   val expect_bytes : t -> bytestring -> unit

--- a/bytestring/bytestring.mli
+++ b/bytestring/bytestring.mli
@@ -42,7 +42,7 @@ module Iter : sig
   val next_utf8 : t -> bytestring
   val next_utf8_seq : len:int -> t -> bytestring
   val rest : t -> bytestring
-  val string_literal : t -> string
+  val rest_as_string : t -> string
   val expect_empty : t -> unit
   val expect_bits : t -> int -> unit
   val expect_bytes : t -> bytestring -> unit

--- a/bytestring/ppx.t/matching.ml
+++ b/bytestring/ppx.t/matching.ml
@@ -78,5 +78,9 @@ let () =
   let _ =
     match%b str with {| hello_world |} -> Bytestring.length hello_world
   in
+  let _ =
+    match%b str with
+    | {| hello_world::string |} -> String.uppercase_ascii hello_world
+  in
 
   ()

--- a/bytestring/ppx.t/run.t
+++ b/bytestring/ppx.t/run.t
@@ -73,7 +73,6 @@
          Valid sizes for string literals are:
          
            string      - match on the entire string
-         literal
            bytes       - match on the entire string
            bytes(expr) - match `expr` bytes
            utf8        - match on 1 UTF-8 grapheme

--- a/bytestring/ppx.t/run.t
+++ b/bytestring/ppx.t/run.t
@@ -95,8 +95,8 @@
          
          Valid sizes are:
          
-           string      - match on the entire string
-         literal
+           string      - match on the entire literal
+         string
            bytes       - match on the entire string
            bytes(expr) - match `expr` bytes
            utf8        - match on 1 UTF-8 grapheme

--- a/bytestring/ppx.t/run.t
+++ b/bytestring/ppx.t/run.t
@@ -94,8 +94,8 @@
          
          Valid sizes are:
          
-           bytes      - match on the literal string
-           string       - match on the entire string
+           bytes       - match on the entire string
+           string      - match on the literal string
            bytes(expr) - match `expr` bytes
            utf8        - match on 1 UTF-8 grapheme
            utf8(expr)  - match `expr` UTF-8 graphemes

--- a/bytestring/ppx.t/run.t
+++ b/bytestring/ppx.t/run.t
@@ -366,7 +366,7 @@
     let _ =
       (fun _data_src ->
          let _data_src = Bytestring.to_iter _data_src in
-         let hello_world = Bytestring.Iter.string_literal _data_src in
+         let hello_world = Bytestring.Iter.rest_as_string _data_src in
          Bytestring.Iter.expect_empty _data_src;
          String.uppercase_ascii hello_world) str in
     ()

--- a/bytestring/ppx.t/run.t
+++ b/bytestring/ppx.t/run.t
@@ -95,9 +95,8 @@
          
          Valid sizes are:
          
-           string      - match on the entire literal
-         string
-           bytes       - match on the entire string
+           bytes      - match on the literal string
+           string       - match on the entire string
            bytes(expr) - match `expr` bytes
            utf8        - match on 1 UTF-8 grapheme
            utf8(expr)  - match `expr` UTF-8 graphemes
@@ -106,7 +105,7 @@
          
          For example:
          
-           hello::string      – use all of `hello` as a literal string
+           hello::string      – use all of `hello` as a string
            hello::bytes       – use all of `hello` as a byte string
            hello::bytes(len)  – use `len` bytes from `hello`
            hello::bits(len)   – use len bits of `hello` (128 bytes)

--- a/bytestring/ppx.t/run.t
+++ b/bytestring/ppx.t/run.t
@@ -72,6 +72,8 @@
          
          Valid sizes for string literals are:
          
+           string      - match on the entire string
+         literal
            bytes       - match on the entire string
            bytes(expr) - match `expr` bytes
            utf8        - match on 1 UTF-8 grapheme
@@ -79,6 +81,7 @@
          
          For example:
          
+           "rush"::string     – use all of the "rush" string
            "rush"::bytes      – use all of the "rush" string
            "rush"::bytes(10)  – use "rush" as a 10-byte string
            "rush"::utf8       – use "rush" as a valid UTF-8 string
@@ -92,6 +95,8 @@
          
          Valid sizes are:
          
+           string      - match on the entire string
+         literal
            bytes       - match on the entire string
            bytes(expr) - match `expr` bytes
            utf8        - match on 1 UTF-8 grapheme
@@ -101,6 +106,7 @@
          
          For example:
          
+           hello::string      – use all of `hello` as a literal string
            hello::bytes       – use all of `hello` as a byte string
            hello::bytes(len)  – use `len` bytes from `hello`
            hello::bits(len)   – use len bits of `hello` (128 bytes)
@@ -359,4 +365,10 @@
     let _ =
       (fun _data_src ->
          let hello_world = _data_src in Bytestring.length hello_world) str in
+    let _ =
+      (fun _data_src ->
+         let _data_src = Bytestring.to_iter _data_src in
+         let hello_world = Bytestring.Iter.string_literal _data_src in
+         Bytestring.Iter.expect_empty _data_src;
+         String.uppercase_ascii hello_world) str in
     ()


### PR DESCRIPTION
Closes #47 