### PR TITLE
feat(riot): add run_with_status function where main can return a status code/error

### DIFF
--- a/riot/riot.ml
+++ b/riot/riot.ml
@@ -40,12 +40,9 @@ let run ?(rnd = Random.State.make_self_init ()) ?workers main =
   Log.debug (fun f -> f "Riot runtime shutdown");
   Stdlib.exit pool.status
 
-let default_on_error error =
-  let error_string = match error with
-    | `Msg reason -> let backtrace = Printexc.get_backtrace () in
-                    Printf.sprintf "%s\n%s" reason backtrace
-    | _ -> "Unsupported error type (please use `Msg or default your own on_error function)"
-  in
+let default_on_error (error:  [ | `Msg of string ]) =
+  let backtrace = Printexc.get_backtrace () in
+  let error_string = Printf.sprintf "%s\n%s" reason backtrace in
   Log.error (fun f -> f "Riot raised an error: %s\n" error_string);
   1
 

--- a/riot/riot.ml
+++ b/riot/riot.ml
@@ -42,7 +42,8 @@ let run ?(rnd = Random.State.make_self_init ()) ?workers main =
 
 let default_on_error (error:  [ | `Msg of string ]) =
   let backtrace = Printexc.get_backtrace () in
-  let error_string = Printf.sprintf "%s\n%s" reason backtrace in
+  let error_string = match error with `Msg reason -> Printf.sprintf "%s\n%s" reason backtrace
+  in
   Log.error (fun f -> f "Riot raised an error: %s\n" error_string);
   1
 

--- a/riot/riot.ml
+++ b/riot/riot.ml
@@ -46,7 +46,7 @@ let default_on_error error =
                     Printf.sprintf "%s\n%s" reason backtrace
     | _ -> "Unsupported error type (please use `Msg or default your own on_error function)"
   in
-  Printf.eprintf "Riot raised an error: %s\n" error_string;
+  Log.error (fun f -> f "Riot raised an error: %s\n" error_string);
   1
 
 let run_with_status ?(rnd = Random.State.make_self_init ()) ?workers ?(on_error = default_on_error) main =

--- a/riot/riot.ml
+++ b/riot/riot.ml
@@ -13,7 +13,7 @@ let shutdown ?(status = 0) () =
 
 let started = ref false
 
-let run_with_status ?(rnd = Random.State.make_self_init ()) ?workers (main:(unit -> (int, [> `Unknown]) result)) =
+let run ?(rnd = Random.State.make_self_init ()) ?workers main =
   if !started then raise Riot_already_started else started := true;
 
   let max_workers = Int.max 0 (Stdlib.Domain.recommended_domain_count () - 2) in
@@ -32,7 +32,7 @@ let run_with_status ?(rnd = Random.State.make_self_init ()) ?workers (main:(unit
   Scheduler.set_current_scheduler sch0;
   Scheduler.Pool.set_pool pool;
 
-  let _pid = _spawn ~pool ~scheduler:sch0 (fun _ -> shutdown ~status:(main () |> Result.get_ok) ()) in
+  let _pid = _spawn ~pool ~scheduler:sch0 main in
   Scheduler.run pool sch0 ();
 
   Log.debug (fun f -> f "Riot runtime shutting down...");
@@ -40,7 +40,10 @@ let run_with_status ?(rnd = Random.State.make_self_init ()) ?workers (main:(unit
   Log.debug (fun f -> f "Riot runtime shutdown");
   Stdlib.exit pool.status
 
-let run ?(rnd = Random.State.make_self_init ()) ?workers main = run_with_status ~rnd ?workers (fun _ -> main (); Ok 0)
+let run_with_status ?(rnd = Random.State.make_self_init ()) ?workers main =
+  run ~rnd ?workers (fun _ ->
+      let status = main () |> Result.get_ok in
+      shutdown ~status ())
 
 let start ?rnd ?workers ~apps () =
   run ?rnd ?workers @@ fun () ->

--- a/riot/riot.ml
+++ b/riot/riot.ml
@@ -51,7 +51,10 @@ let default_on_error error =
 
 let run_with_status ?(rnd = Random.State.make_self_init ()) ?workers ?(on_error = default_on_error) main =
   run ~rnd ?workers (fun _ ->
-      let status: int = Result.fold ~ok:Fun.id ~error:on_error @@ main () in
+      let status = match main () with
+        | Ok code -> code
+        | Error reason -> on_error reason
+      in
       shutdown ~status ())
 
 let start ?rnd ?workers ~apps () =

--- a/riot/riot.ml
+++ b/riot/riot.ml
@@ -40,18 +40,19 @@ let run ?(rnd = Random.State.make_self_init ()) ?workers main =
   Log.debug (fun f -> f "Riot runtime shutdown");
   Stdlib.exit pool.status
 
-let default_on_error (error:  [ | `Msg of string ]) =
+let on_error (error : [ `Msg of string ]) =
   let backtrace = Printexc.get_backtrace () in
-  let error_string = match error with `Msg reason -> Printf.sprintf "%s\n%s" reason backtrace
+  let error_string =
+    match error with `Msg reason -> Printf.sprintf "%s\n%s" reason backtrace
   in
   Log.error (fun f -> f "Riot raised an error: %s\n" error_string);
   1
 
-let run_with_status ?(rnd = Random.State.make_self_init ()) ?workers ?(on_error = default_on_error) main =
+let run_with_status ?(rnd = Random.State.make_self_init ()) ?workers ~on_error
+    main =
   run ~rnd ?workers (fun _ ->
-      let status = match main () with
-        | Ok code -> code
-        | Error reason -> on_error reason
+      let status =
+        match main () with Ok code -> code | Error reason -> on_error reason
       in
       shutdown ~status ())
 

--- a/riot/riot.mli
+++ b/riot/riot.mli
@@ -304,10 +304,11 @@ val shutdown : ?status:int -> unit -> unit
 val run : ?rnd:Random.State.t -> ?workers:int -> (unit -> unit) -> unit
 (** Start the Riot runtime using function [main] to boot the system *)
 
-val run_with_status : ?rnd:Random.State.t -> ?workers:int -> (unit -> (int, [> `Msg of string ]) result) -> unit
+val run_with_status : ?rnd:Random.State.t -> ?workers:int -> ?on_error:(([> `Msg of string ] as 'a) -> int) -> (unit -> (int, 'a) result) -> unit
 (** Start the Riot runtime using function [main] to boot the system.
 
     [main] should return a result of either an exit code or an error, for use in quick prototyping.
+    [on_error] should handle an error code appropriately, then return a status code (defaults to 1).
 *)
 
 val start :

--- a/riot/riot.mli
+++ b/riot/riot.mli
@@ -304,7 +304,7 @@ val shutdown : ?status:int -> unit -> unit
 val run : ?rnd:Random.State.t -> ?workers:int -> (unit -> unit) -> unit
 (** Start the Riot runtime using function [main] to boot the system *)
 
-val run_with_status : ?rnd:Random.State.t -> ?workers:int -> (unit -> (int, [> `Unknown]) result) -> unit
+val run_with_status : ?rnd:Random.State.t -> ?workers:int -> (unit -> (int, [> `Msg of string ]) result) -> unit
 (** Start the Riot runtime using function [main] to boot the system.
 
     [main] should return a result of either an exit code or an error, for use in quick prototyping.

--- a/riot/riot.mli
+++ b/riot/riot.mli
@@ -304,7 +304,7 @@ val shutdown : ?status:int -> unit -> unit
 val run : ?rnd:Random.State.t -> ?workers:int -> (unit -> unit) -> unit
 (** Start the Riot runtime using function [main] to boot the system *)
 
-val run_with_status : ?rnd:Random.State.t -> ?workers:int -> ?on_error:(([> `Msg of string ] as 'a) -> int) -> (unit -> (int, 'a) result) -> unit
+val run_with_status : ?rnd:Random.State.t -> ?workers:int -> ?on_error:('error -> int) -> (unit -> (int, 'error) result) -> unit
 (** Start the Riot runtime using function [main] to boot the system.
 
     [main] should return a result of either an exit code or an error, for use in quick prototyping.

--- a/riot/riot.mli
+++ b/riot/riot.mli
@@ -304,6 +304,12 @@ val shutdown : ?status:int -> unit -> unit
 val run : ?rnd:Random.State.t -> ?workers:int -> (unit -> unit) -> unit
 (** Start the Riot runtime using function [main] to boot the system *)
 
+val run_with_status : ?rnd:Random.State.t -> ?workers:int -> (unit -> (int, [> `Unknown]) result) -> unit
+(** Start the Riot runtime using function [main] to boot the system.
+
+    [main] should return a result of either an exit code or an error, for use in quick prototyping.
+*)
+
 val start :
   ?rnd:Random.State.t ->
   ?workers:int ->

--- a/riot/riot.mli
+++ b/riot/riot.mli
@@ -304,11 +304,19 @@ val shutdown : ?status:int -> unit -> unit
 val run : ?rnd:Random.State.t -> ?workers:int -> (unit -> unit) -> unit
 (** Start the Riot runtime using function [main] to boot the system *)
 
-val run_with_status : ?rnd:Random.State.t -> ?workers:int -> ?on_error:('error -> int) -> (unit -> (int, 'error) result) -> unit
-(** Start the Riot runtime using function [main] to boot the system.
+val on_error : [ `Msg of string ] -> int
 
-    [main] should return a result of either an exit code or an error, for use in quick prototyping.
-    [on_error] should handle an error code appropriately, then return a status code (defaults to 1).
+val run_with_status :
+  ?rnd:Random.State.t ->
+  ?workers:int ->
+  on_error:('error -> int) ->
+  (unit -> (int, 'error) result) ->
+  unit
+(** [run_with_status ~on_error main] starts the Riot runtime using function
+    [main] to boot the system and handling errors with [on_error].
+
+    [main] should return a result of either an exit code or an error.
+    [on_error] should handle an error code appropriately, then return a status code.
 *)
 
 val start :


### PR DESCRIPTION
This attempts to resolve #50

Sorry if anything here is wrong/misunderstanding the issue, I'm still a bit new to OCaml.
I created another function, `run_with_status`, which implements the expected behaviour to avoid making a breaking change. I didn't know what the error type should be, and the issue said to make it a polymorphic variant, so I added a placeholder `` `Unknown `` variant for now. I'm assuming it should accept an io_error, but that requires moving the `run` functions down ~200 lines so I want to make sure that's okay before doing that. Running `dune test` in the root directory seems to suggest nothing has broken.

I implemented the regular `run` function in terms of `run_with_status`. I don't think that's optimal for performance if `run` is going to be used in production, should I change that so `run_with_status` is a wrapper around `run`? Currently, the two run functions are swapped around in the mli, and I just noticed that everything else is in the same order in the interface and implementation files. Is this a convention that I should follow or just coincidence?

Also, should I write a test for this function?