### PR TITLE
removed a "skipping" I don't think is needed

### DIFF
--- a/gluon/net.ml
+++ b/gluon/net.ml
@@ -42,9 +42,7 @@ module Addr = struct
         match ai_protocol with
         | 6 -> Some (tcp (Unix.string_of_inet_addr addr) port)
         | _ -> None)
-    | _ ->
-        Printf.printf "skipping\n%!";
-        None
+    | _ -> None
 
   let get_info host service =
     syscall @@ fun () ->


### PR DESCRIPTION
I got a "Skipping" output to stdout when working with the Net module. I don't know if it's needed so I created a PR for it. 

Didn't look as we print "skipping" on line 44 within the same function