### PR TITLE
Update randomconv lib usage to convert to string to support 0.2.0

### DIFF
--- a/riot/lib/crypto.ml
+++ b/riot/lib/crypto.ml
@@ -2,17 +2,18 @@ let () = Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna)
 
 module Random = struct
   let cstruct n = Mirage_crypto_rng.generate n
-  let int8 () = Randomconv.int8 cstruct
-  let int16 () = Randomconv.int16 cstruct
-  let int32 () = Randomconv.int32 cstruct
-  let int64 () = Randomconv.int64 cstruct
+  let cstruct_to_string n = Mirage_crypto_rng.generate n |> Cstruct.to_string
+  let int8 () = Randomconv.int8 cstruct_to_string
+  let int16 () = Randomconv.int16 cstruct_to_string
+  let int32 () = Randomconv.int32 cstruct_to_string
+  let int64 () = Randomconv.int64 cstruct_to_string
   let char () = Char.chr (int8 ())
-  let int ?max () = Randomconv.int ?bound:max cstruct
-  let float ?max () = Randomconv.float ?bound:max cstruct
+  let int ?max () = Randomconv.int ?bound:max cstruct_to_string
+  let float ?max () = Randomconv.float ?bound:max cstruct_to_string
   let bytes n = cstruct n |> Cstruct.to_bytes
   let bigarray n = cstruct n |> Cstruct.to_bigarray
   let string n = cstruct n |> Cstruct.to_string
   let bytestring n = string n |> Bytestring.of_string
-  let alphanum () = Char.chr (48 + Randomconv.int ~bound:74 cstruct)
+  let alphanum () = Char.chr (48 + Randomconv.int ~bound:74 cstruct_to_string)
   let seq n gen = List.init n (fun _ -> gen ()) |> List.to_seq |> String.of_seq
 end


### PR DESCRIPTION
THERE IS AN ALTERNATIVE SOLUTION HERE: https://github.com/riot-ml/riot/pull/69

The 0.2.0 release of `randomconv` changed the signature of its functions: https://github.com/hannesm/randomconv/releases , which is causing builds of Riot to fail.

This PR updates the usage of `randomconv` so that we convert Cstructs to a string like Randomconv expects.