### PR TITLE
Pin randomconv lib to < 0.2.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -33,7 +33,7 @@
   (ocaml (>= "5.1"))
   (odoc (and :with-doc (>= "2.2.2")))
   (ptime (>= "1.1.0"))
-  (randomconv (>= "0.1.3"))
+  (randomconv (and (>= "0.1.3") (< "0.2.0")))
   (telemetry (>= "0.0.1"))
   (tls (>="0.17.3"))
   (uri (>= "4.4.0"))

--- a/riot.opam
+++ b/riot.opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "5.1"}
   "odoc" {with-doc & >= "2.2.2"}
   "ptime" {>= "1.1.0"}
-  "randomconv" {>= "0.1.3"}
+  "randomconv" {>= "0.1.3" & < "0.2.0"}
   "telemetry" {>= "0.0.1"}
   "tls" {>= "0.17.3"}
   "uri" {>= "4.4.0"}


### PR DESCRIPTION
THERE IS AN ALTERNATIVE SOLUTION HERE: https://github.com/riot-ml/riot/pull/68

The 0.2.0 release of `randomconv` changed the signature of its functions: https://github.com/hannesm/randomconv/releases , which is causing builds of Riot to fail.

This PR simply adds a `< 0.2.0` pin to the randomconv dependency, which will fix the builds until Riot is updated