### PR TITLE
feat: implement message selectors

### DIFF
--- a/bench/http_server.ml
+++ b/bench/http_server.ml
@@ -10,7 +10,7 @@ let bufs = IO.Iovec.create ~size:1024 ()
 
 let rec conn_loop conn () =
   let rec handle_request () =
-    match receive ~after:10L () with
+    match receive_any ~after:10L () with
     | exception Receive_timeout ->
         let* _req = Net.Tcp_stream.receive ~timeout:1_000_000L conn ~bufs in
         let* _written =

--- a/bench/spawn_many.ml
+++ b/bench/spawn_many.ml
@@ -25,6 +25,12 @@ module Test_app = struct
 
     List.iter (fun pid -> send pid Loop_stop) pids;
 
+    Logger.info (fun f ->
+        let t1 = Ptime_clock.now () in
+        let delta = Ptime.diff t1 t0 in
+        let delta = Ptime.Span.to_float_s delta in
+        f "sent %d messages in %.3fs" (List.length pids) delta);
+
     wait_pids pids;
 
     Logger.info (fun f ->

--- a/bench/spawn_many.ml
+++ b/bench/spawn_many.ml
@@ -6,7 +6,7 @@ module Test_app = struct
   type Riot.Message.t += Loop_stop
 
   let loop count =
-    match receive () with
+    match receive_any () with
     | Loop_stop -> Log.debug (fun f -> f "dead at %d%!" count)
 
   let main t0 () =

--- a/examples/3-message-passing/main.ml
+++ b/examples/3-message-passing/main.ml
@@ -6,7 +6,7 @@ let () =
   Riot.run @@ fun () ->
   let pid =
     spawn (fun () ->
-        match[@warning "-8"] receive () with
+        match[@warning "-8"] receive_any () with
         | Hello_world -> print_endline "Hello, World! :D")
   in
   send pid Hello_world

--- a/examples/4-long-lived-processes/main.ml
+++ b/examples/4-long-lived-processes/main.ml
@@ -5,7 +5,7 @@ type Message.t += Hello of string
 let () =
   Riot.run @@ fun () ->
   let rec loop () =
-    (match receive () with
+    (match receive_any () with
     | Hello name -> print_endline ("Hello, " ^ name ^ "! :D")
     | _ -> print_endline "Oh no, an unhandled message! D:");
     loop ()

--- a/examples/5-links-and-monitors/main.ml
+++ b/examples/5-links-and-monitors/main.ml
@@ -1,7 +1,7 @@
 open Riot
 
 let rec await_monitor_message () =
-  match receive () with
+  match receive_any () with
   | Process.Messages.Monitor (Process_down pid) ->
       Format.printf "uh-oh! Process %a terminated\n%!" Pid.pp pid
   | _ -> await_monitor_message ()

--- a/riot/lib/logger_app.ml
+++ b/riot/lib/logger_app.ml
@@ -12,7 +12,7 @@ module Formatter = struct
     Format.make_formatter (output_substring stdout) (fun () -> flush stdout)
 
   let rec formatter_loop config =
-    match receive () with
+    match receive_any () with
     | Log { message; ts; src = sch, pid; level; ns } ->
         let pp_now = Ptime.pp_rfc3339 ~frac_s:5 ~space:true ~tz_offset_s:0 () in
 

--- a/riot/lib/runtime_lib.ml
+++ b/riot/lib/runtime_lib.ml
@@ -68,7 +68,7 @@ compactions=%d
   let rec loop () =
     print_scheduler_stats ();
     print_gc_stats ();
-    receive () |> ignore;
+    receive_any () |> ignore;
     loop ()
 
   let start ?(every = 2_000_000L) () =

--- a/riot/lib/task.ml
+++ b/riot/lib/task.ml
@@ -21,38 +21,30 @@ let async fn =
   Process.monitor pid;
   { pid; ref }
 
-let rec await :
+let await :
     type res.
     ?timeout:int64 -> res t -> (res, [> `Timeout | `Process_down ]) result =
  fun ?timeout:after t ->
-  let started_at =
-    Int64.add (Mtime_clock.now_ns ()) (Option.value ~default:0L after)
-  in
   Logger.trace (fun f ->
       f "Process %a is awaing for task %a with timeout %Ld" Pid.pp (self ())
         Pid.pp t.pid
         (Option.value ~default:(-1L) after));
-  match receive ?after () with
+  let selector : [ `reply of res | `process_down ] Message.selector =
+   fun msg ->
+    match msg with
+    | Reply (ref', res) when Ref.equal t.ref ref' -> (
+        match Ref.type_equal t.ref ref' with
+        | Some Type.Equal -> `select (`reply res)
+        | None -> failwith "bad message")
+    | Process.Messages.Monitor (Process_down pid) when Pid.equal pid t.pid ->
+        `select `process_down
+    | _ -> `skip
+  in
+  match receive ~selector ?after () with
   | exception Receive_timeout ->
       Logger.trace (fun f -> f "task %a timeout" Pid.pp t.pid);
       Error `Timeout
-  | Reply (ref', res) when Ref.equal t.ref ref' -> (
+  | `reply res ->
       Process.demonitor t.pid;
-      match Ref.type_equal t.ref ref' with
-      | Some Type.Equal -> Ok res
-      | None -> failwith "bad message")
-  | Process.Messages.Monitor (Process_down pid) when Pid.equal pid t.pid ->
-      Error `Process_down
-  | Process.Messages.Monitor (Process_down pid) ->
-      Logger.error (fun f ->
-          f
-            "received wrong monitor process down for %a (we are %a, our task \
-             is %a)"
-            Pid.pp pid Pid.pp (self ()) Pid.pp t.pid);
-      Error `Process_down
-  | msg ->
-      Logger.trace (fun f ->
-          f "requeuing message %S" (Marshal.to_string msg []));
-      send (self ()) msg;
-      let timeout = Int64.sub started_at (Mtime_clock.now_ns ()) in
-      await ~timeout t
+      Ok res
+  | `process_down -> Error `Process_down

--- a/riot/lib/telemetry_app.ml
+++ b/riot/lib/telemetry_app.ml
@@ -10,7 +10,7 @@ module Dispatcher = struct
   let __main_dispatcher__ : Pid.t ref = ref Pid.zero
 
   let rec loop () =
-    match receive () with
+    match receive_any () with
     | Event e ->
         Telemetry.emit e;
         loop ()

--- a/riot/riot.mli
+++ b/riot/riot.mli
@@ -69,14 +69,7 @@ module Message : sig
       program can see the constructors that are relevant for them.
     *)
 
-  (** [select_marker] is used in a _selective receive_ call to match the exact
-      messages you are looking for. This is useful to skip ahead in your
-      mailbox without having to consume all the messages in it.
-  *)
-  type select_marker =
-    | Take  (** use [Take] to mark a message as selected *)
-    | Skip  (** use [Skip] to requeue for later consumption *)
-    | Drop  (** use [Drop] to remove this message while selecting *)
+  type 'msg selector = t -> [ `select of 'msg | `skip ]
 end
 
 module Process : sig
@@ -269,7 +262,7 @@ exception Receive_timeout
 exception Syscall_timeout
 
 val receive :
-  ?selector:(Message.t -> [ `select of 'msg | `skip ]) ->
+  selector:(Message.t -> [ `select of 'msg | `skip ]) ->
   ?after:int64 ->
   ?ref:unit Ref.t ->
   unit ->
@@ -301,6 +294,9 @@ val receive :
     it. Those messages will be delivered in-order in future calls to `receive
     ()`.
 *)
+
+val receive_any : ?after:int64 -> ?ref:unit Ref.t -> unit -> Message.t
+(** [receive_any ()] behaves like [receive] but does not require a [selector] and instead will return any message in the mailbox. *)
 
 val shutdown : ?status:int -> unit -> unit
 (** Gracefully shuts down the runtime. Any non-yielding process will block this. *)

--- a/riot/riot.mli
+++ b/riot/riot.mli
@@ -268,7 +268,12 @@ val wait_pids : Pid.t list -> unit
 exception Receive_timeout
 exception Syscall_timeout
 
-val receive : ?after:int64 -> ?ref:unit Ref.t -> unit -> Message.t
+val receive :
+  ?selector:(Message.t -> [ `select of 'msg | `skip ]) ->
+  ?after:int64 ->
+  ?ref:unit Ref.t ->
+  unit ->
+  'msg
 (** [receive ()] will return the first message in the process mailbox.
 
     This function will suspend a process that has an empty mailbox, and the
@@ -282,6 +287,11 @@ val receive : ?after:int64 -> ?ref:unit Ref.t -> unit -> Message.t
     This is useful to prevent deadlock of processes when receiving messages.
 
     ### Selective Receive
+
+    If a `selector` was passed, the `selector` function will be used to select
+    if a message will be picked or if it will be skipped.
+
+    ### Receive with Refs
 
     If a `ref` was passed, then `[receive ~ref ()]` will skip all messages
     created before the creation of this `Ref.t` value, and will only return

--- a/riot/runtime/core/message.ml
+++ b/riot/runtime/core/message.ml
@@ -1,5 +1,5 @@
 type t = ..
-type select_marker = Take | Skip | Drop
+type 'msg selector = t -> [ `select of 'msg | `skip ]
 type envelope = { msg : t; uid : unit Ref.t }
 
 let envelope msg = { uid = Ref.make (); msg }

--- a/riot/runtime/core/message.mli
+++ b/riot/runtime/core/message.mli
@@ -1,5 +1,0 @@
-type t = ..
-type select_marker = Take | Skip | Drop
-type envelope = { msg : t; uid : unit Ref.t }
-
-val envelope : t -> envelope

--- a/riot/runtime/core/proc_effect.ml
+++ b/riot/runtime/core/proc_effect.ml
@@ -5,8 +5,9 @@ type _ Effect.t +=
   | Receive : {
       ref : 'a Ref.t option;
       timeout : Timeout.t;
+      selector : Message.t -> [ `select of 'msg | `skip ];
     }
-      -> Message.t Effect.t
+      -> 'msg Effect.t
   [@@unboxed]
 
 type _ Effect.t += Yield : unit Effect.t [@@unboxed]

--- a/riot/runtime/import.ml
+++ b/riot/runtime/import.ml
@@ -17,13 +17,21 @@ let syscall ?timeout name interest source cb =
   Effect.perform (Proc_effect.Syscall { name; interest; source; timeout });
   cb ()
 
-let default_selector msg = `select msg
-
-let receive ?(selector = default_selector) ?after ?ref () =
+let receive :
+    type msg.
+    selector:(Message.t -> [ `select of msg | `skip ]) ->
+    ?after:int64 ->
+    ?ref:unit Ref.t ->
+    unit ->
+    msg =
+ fun ~selector ?after ?ref () ->
   let timeout =
     match after with None -> `infinity | Some after -> `after after
   in
   Effect.perform (Proc_effect.Receive { ref; timeout; selector })
+
+let receive_any ?after ?ref () =
+  receive ~selector:(fun msg -> `select msg) ?after ?ref ()
 
 let yield () = Effect.perform Proc_effect.Yield
 let random () = (_get_sch ()).rnd

--- a/riot/runtime/import.ml
+++ b/riot/runtime/import.ml
@@ -17,11 +17,13 @@ let syscall ?timeout name interest source cb =
   Effect.perform (Proc_effect.Syscall { name; interest; source; timeout });
   cb ()
 
-let receive ?after ?ref () =
+let default_selector msg = `select msg
+
+let receive ?(selector = default_selector) ?after ?ref () =
   let timeout =
     match after with None -> `infinity | Some after -> `after after
   in
-  Effect.perform (Proc_effect.Receive { ref; timeout })
+  Effect.perform (Proc_effect.Receive { ref; timeout; selector })
 
 let yield () = Effect.perform Proc_effect.Yield
 let random () = (_get_sch ()).rnd

--- a/riot/runtime/import.ml
+++ b/riot/runtime/import.ml
@@ -211,10 +211,12 @@ let wait_pids pids =
   (* And we can enter the receive loop, filtering out the pids as they come.
      When the list of pids becomes empty, we exit the recursion. *)
   let rec do_wait pids =
-    match receive ~selector () with
-    | Process_down pid ->
-        let pids = List.filter (fun pid' -> not (Pid.equal pid' pid)) pids in
-        if List.length pids = 0 then () else do_wait pids
+    if List.length pids = 0 then ()
+    else
+      match receive ~selector () with
+      | Process_down pid ->
+          let pids = List.filter (fun pid' -> not (Pid.equal pid' pid)) pids in
+          do_wait pids
   in
   do_wait pids
 

--- a/test/add_monitor_test.ml
+++ b/test/add_monitor_test.ml
@@ -8,7 +8,7 @@ let main () =
   let pid = spawn (fun () -> ()) in
   Process.monitor pid;
 
-  match receive ~after:500_000L () with
+  match receive_any ~after:500_000L () with
   | Process.Messages.Monitor (Process_down pid2) when Pid.equal pid pid2 ->
       Logger.debug (fun f -> f "add_monitor: was notified of process death");
       Logger.info (fun f -> f "add_monitor: OK");

--- a/test/cancel_timer_test.ml
+++ b/test/cancel_timer_test.ml
@@ -14,7 +14,7 @@ let main () =
   let (Ok _) = Timer.send_after this A ~after:100L in
   let (Ok t) = Timer.send_after this B ~after:10L in
   Timer.cancel t;
-  match receive ~after:10_000L () with
+  match receive_any ~after:10_000L () with
   | A ->
       Logger.debug (fun f ->
           f "cancel_timer_test: timer successfully cancelled");

--- a/test/link_processes_test.ml
+++ b/test/link_processes_test.ml
@@ -26,6 +26,8 @@ let main () =
         loop ())
   in
 
+  List.iter monitor [ pid1; pid2 ];
+
   sleep 0.5;
   (* once we send this exit signal to pid1, and it dies, it should take pid2 down with it *)
   exit pid1 Normal;

--- a/test/link_processes_test.ml
+++ b/test/link_processes_test.ml
@@ -26,11 +26,12 @@ let main () =
         loop ())
   in
 
-  List.iter monitor [ pid1; pid2 ];
-
-  sleep 0.5;
-  (* once we send this exit signal to pid1, and it dies, it should take pid2 down with it *)
-  exit pid1 Normal;
+  let _ =
+    spawn (fun () ->
+        sleep 0.5;
+        (* once we send this exit signal to pid1, and it dies, it should take pid2 down with it *)
+        exit pid1 Normal)
+  in
 
   (* so we'll wait for both pids to be dead *)
   wait_pids [ pid1; pid2 ];

--- a/test/net_reader_writer_test.ml
+++ b/test/net_reader_writer_test.ml
@@ -97,7 +97,7 @@ let () =
   let client = spawn (fun () -> client port main) in
   monitor server;
   monitor client;
-  match receive ~after:500_000L () with
+  match receive_any ~after:500_000L () with
   | Received "hello world\r\n" ->
       Logger.info (fun f -> f "net_reader_writer_test: OK");
 

--- a/test/net_test.ml
+++ b/test/net_test.ml
@@ -93,7 +93,7 @@ let () =
   let client = spawn (fun () -> client port main) in
   monitor server;
   monitor client;
-  match receive ~after:10_000_000L () with
+  match receive_any ~after:10_000_000L () with
   | exception Receive_timeout ->
       Logger.error (fun f -> f "net_test: test timed out");
       fail ()

--- a/test/process_priority_test.ml
+++ b/test/process_priority_test.ml
@@ -29,9 +29,9 @@ let main () =
         loop this C 100)
   in
 
-  let m1 = receive ~after:50_000L () in
-  let m2 = receive ~after:50_000L () in
-  let m3 = receive ~after:50_000L () in
+  let m1 = receive_any ~after:50_000L () in
+  let m2 = receive_any ~after:50_000L () in
+  let m3 = receive_any ~after:50_000L () in
 
   match (m1, m2, m3) with
   | C, B, A ->

--- a/test/process_registration_test.ml
+++ b/test/process_registration_test.ml
@@ -23,7 +23,7 @@ module Registry_test = struct
 
     send_by_name ~name:pid_name Hello;
 
-    (match[@warning "-8"] receive ~after:500_000L () with
+    (match[@warning "-8"] receive_any ~after:500_000L () with
     | Hello ->
         Logger.debug (fun f ->
             f "process_registration_test: send_by_name works"));

--- a/test/readme_example.ml
+++ b/test/readme_example.ml
@@ -9,8 +9,13 @@ let () =
   Riot.run @@ fun () ->
   let pid =
     spawn (fun () ->
-        match receive () with
-        | Hello_world ->
+      let selector msg = 
+        match msg with
+        | Hello_world -> `select `hello_world
+        | _ -> `skip 
+      in
+        match receive ~selector () with
+        | `hello_world ->
             Logger.info (fun f -> f "hello world from %a!" Pid.pp (self ()));
             shutdown ())
   in

--- a/test/readme_example.ml
+++ b/test/readme_example.ml
@@ -9,11 +9,9 @@ let () =
   Riot.run @@ fun () ->
   let pid =
     spawn (fun () ->
-      let selector msg = 
-        match msg with
-        | Hello_world -> `select `hello_world
-        | _ -> `skip 
-      in
+        let selector msg =
+          match msg with Hello_world -> `select `hello_world | _ -> `skip
+        in
         match receive ~selector () with
         | `hello_world ->
             Logger.info (fun f -> f "hello world from %a!" Pid.pp (self ()));

--- a/test/receive_timeout_test.ml
+++ b/test/receive_timeout_test.ml
@@ -8,7 +8,7 @@ let () =
   Logger.set_log_level (Some Info);
   let _ = Timer.send_after (self ()) Unexpected ~after:100L |> Result.get_ok in
 
-  match receive ~after:1L () with
+  match receive_any ~after:1L () with
   | exception Receive_timeout ->
       Logger.info (fun f -> f "receive_timeout_test: OK");
 

--- a/test/selective_receive_test.ml
+++ b/test/selective_receive_test.ml
@@ -6,7 +6,7 @@ type Message.t += A | B | C | Continue
 
 let loop pid =
   send pid A;
-  receive ~after:500_000L () |> ignore;
+  receive_any ~after:500_000L () |> ignore;
   send pid B;
   send pid C
 
@@ -22,9 +22,9 @@ let main () =
   let ref = Ref.make () in
   send pid1 Continue;
 
-  let m1 = receive ~ref ~after:50_000L () in
-  let m2 = receive ~ref ~after:50_000L () in
-  let m3 = receive ~after:50_000L () in
+  let m1 = receive_any ~ref ~after:50_000L () in
+  let m2 = receive_any ~ref ~after:50_000L () in
+  let m3 = receive_any ~after:50_000L () in
 
   match (m1, m2, m3) with
   | B, C, A ->

--- a/test/send_after_test.ml
+++ b/test/send_after_test.ml
@@ -14,7 +14,7 @@ let msg_to_str = function
 
 let main () =
   let (Ok _) = Logger.start () in
-  Runtime.set_log_level (Some Trace);
+  (* Runtime.set_log_level (Some Trace); *)
   Logger.set_log_level (Some Info);
   let this = self () in
 
@@ -27,11 +27,11 @@ let main () =
   let after = 10_000L in
   let messages =
     [
-      receive ~after ();
-      receive ~after ();
-      receive ~after ();
-      receive ~after ();
-      receive ~after ();
+      receive_any ~after ();
+      receive_any ~after ();
+      receive_any ~after ();
+      receive_any ~after ();
+      receive_any ~after ();
     ]
     |> List.rev
   in

--- a/test/send_interval_test.ml
+++ b/test/send_interval_test.ml
@@ -12,8 +12,8 @@ let main () =
 
   let (Ok _timer) = Timer.send_interval this A ~every:50L in
 
-  let A = receive ~after:2000L () in
-  let A = receive ~after:2000L () in
+  let A = receive_any ~after:2000L () in
+  let A = receive_any ~after:2000L () in
 
   Logger.debug (fun f -> f "send_interval_test: messages sent with interval");
   Logger.info (fun f -> f "send_interval_test: OK");

--- a/test/send_order_test.ml
+++ b/test/send_order_test.ml
@@ -10,7 +10,7 @@ type Riot.Message.t +=
 type state = { messages : Riot.Message.t list; main : Pid.t }
 
 let rec loop state =
-  match receive ~after:500_000L () with
+  match receive_any ~after:500_000L () with
   | End -> send state.main (Collected_messages (List.rev state.messages))
   | A _ as msg -> loop { state with messages = msg :: state.messages }
   | _ -> loop state
@@ -25,7 +25,7 @@ let main () =
   send pid (A 3);
   send pid End;
 
-  match receive ~after:500_000L () with
+  match receive_any ~after:500_000L () with
   | Collected_messages [ A 1; A 2; A 3 ] ->
       Logger.debug (fun f -> f "send_order_test: received messages in order");
       Logger.info (fun f -> f "send_order_test: OK");

--- a/test/ssl_test.ml
+++ b/test/ssl_test.ml
@@ -134,7 +134,7 @@ let () =
   in
   monitor server;
   monitor client;
-  match receive ~after:500_000L () with
+  match receive_any ~after:500_000L () with
   | Received "hello world" -> Logger.info (fun f -> f "ssl_test: OK")
   | Received other ->
       Logger.error (fun f -> f "ssl_test: bad payload: %S" other);

--- a/test/supervisor_shutdown_test.ml
+++ b/test/supervisor_shutdown_test.ml
@@ -31,22 +31,22 @@ let main () =
     |> Result.get_ok
   in
 
-  let (Ping_me child_pid) = receive ~after:500_000L () in
+  let (Ping_me child_pid) = receive_any ~after:500_000L () in
   Logger.debug (fun f -> f "#1 received pid %a" Pid.pp child_pid);
 
   exit child_pid Process.Exit_signal;
 
-  let (Ping_me child_pid) = receive ~after:500_000L () in
+  let (Ping_me child_pid) = receive_any ~after:500_000L () in
   Logger.debug (fun f -> f "#2 received pid %a" Pid.pp child_pid);
 
   exit child_pid Process.Exit_signal;
 
-  let (Ping_me child_pid) = receive ~after:500_000L () in
+  let (Ping_me child_pid) = receive_any ~after:500_000L () in
   Logger.debug (fun f -> f "#3 received pid %a" Pid.pp child_pid);
 
   exit child_pid Process.Exit_signal;
 
-  match receive ~after:500_000L () with
+  match receive_any ~after:500_000L () with
   | Process.Messages.Exit (pid, _reason) when Pid.equal pid sup ->
       Logger.info (fun f ->
           f "supervisor_shutdown_test: supervisor finished as expected");


### PR DESCRIPTION
This PR reintroduces message selectors to the `receive` expression, and it introduces a new `receive_any` expression that skips the selection entirely.

We can use these to:

* get rid of the catch-all messages in `receive` expressions
* implement selective receives for Task, GenServer, and similar cases efficiently
* implement `wait_pids` efficiently