### PR TITLE
Fix warning 53 (unboxed attribute used in the wrong location)

### DIFF
--- a/riot/lib/logger_app.ml
+++ b/riot/lib/logger_app.ml
@@ -6,7 +6,7 @@ open Logger.Make (struct
 end)
 
 module Formatter = struct
-  type Message.t += Log of log [@@unboxed]
+  type Message.t += Log of log
 
   let stdout =
     Format.make_formatter (output_substring stdout) (fun () -> flush stdout)

--- a/riot/lib/telemetry_app.ml
+++ b/riot/lib/telemetry_app.ml
@@ -5,7 +5,7 @@ type event = Telemetry.event = ..
 let name = "Riot.Telemetry"
 
 module Dispatcher = struct
-  type Core.Message.t += Event of Telemetry.event [@@unboxed]
+  type Core.Message.t += Event of Telemetry.event
 
   let __main_dispatcher__ : Pid.t ref = ref Pid.zero
 

--- a/riot/runtime/core/proc_effect.ml
+++ b/riot/runtime/core/proc_effect.ml
@@ -8,9 +8,8 @@ type _ Effect.t +=
       selector : Message.t -> [ `select of 'msg | `skip ];
     }
       -> 'msg Effect.t
-  [@@unboxed]
 
-type _ Effect.t += Yield : unit Effect.t [@@unboxed]
+type _ Effect.t += Yield : unit Effect.t
 
 type _ Effect.t +=
   | Syscall : {
@@ -20,4 +19,3 @@ type _ Effect.t +=
       timeout : Timeout.t;
     }
       -> unit Effect.t
-  [@@unboxed]


### PR DESCRIPTION
When running `dune build @check` from the root of the repository, here is one instance of the warning 53 I get.

    File "riot/runtime/core/proc_effect.ml", line 23, characters 5-12:
    23 |   [@@unboxed]
              ^^^^^^^
    Error (warning 53 [misplaced-attribute]): the "unboxed" attribute
    cannot appear in this context

This patch removes the incorrect `unboxed` attribute where needed, to make the codebase warning free.