### PR TITLE
Implement handle_cast and handle_continue

### DIFF
--- a/riot/lib/gen_server.ml
+++ b/riot/lib/gen_server.ml
@@ -1,10 +1,12 @@
 open Global
 
 type 'res req = ..
+type cast_req = ..
 type cont_req = ..
 
 type Message.t +=
   | Call : Pid.t * 'res Ref.t * 'res req -> Message.t
+  | Cast : cast_req -> Message.t
   | Reply : 'res Ref.t * 'res -> Message.t
 
 type 'state init_result = Ok of 'state | Error | Ignore
@@ -13,6 +15,8 @@ type ('res, 'state) call_result =
   | Reply of ('res * 'state)
   | Reply_continue of ('res * 'state * cont_req)
 
+type 'state cast_result = No_reply of 'state
+
 module type Impl = sig
   type args
   type state
@@ -20,9 +24,9 @@ module type Impl = sig
   val init : args -> state init_result
 
   val handle_call :
-    'res.
-    'res req -> Pid.t -> state -> ('res, state) call_result
+    'res. 'res req -> Pid.t -> state -> ('res, state) call_result
 
+  val handle_cast : cast_req -> state -> state cast_result
   val handle_continue : cont_req -> state -> state
   val handle_info : Message.t -> state -> unit
 end
@@ -45,6 +49,8 @@ let call : type res. Pid.t -> res req -> res =
   in
   receive ~selector ()
 
+let cast pid req = send pid (Cast req)
+
 let rec loop : type args state. (args, state) impl -> state -> unit =
  fun impl state ->
   let (module I : Impl with type args = args and type state = state) = impl in
@@ -58,6 +64,8 @@ let rec loop : type args state. (args, state) impl -> state -> unit =
           send pid (Reply (ref, res));
           let state = I.handle_continue cont_req state in
           loop impl state)
+  | Cast req -> (
+      match I.handle_cast req state with No_reply state -> loop impl state)
   | msg ->
       let _res = I.handle_info msg state in
       loop impl state
@@ -80,6 +88,7 @@ let start_link :
 module Default = struct
   let init _args = Ignore
   let handle_call _req _from _state = failwith "unimplemented"
+  let handle_cast _req _state = failwith "unimplemented"
   let handle_continue _req _state = failwith "unimplemented"
   let handle_info _msg _state = failwith "unimplemented"
 end

--- a/riot/lib/gen_server.ml
+++ b/riot/lib/gen_server.ml
@@ -1,6 +1,7 @@
 open Global
 
 type 'res req = ..
+type cont_req = ..
 
 type Message.t +=
   | Call : Pid.t * 'res Ref.t * 'res req -> Message.t
@@ -8,12 +9,21 @@ type Message.t +=
 
 type 'state init_result = Ok of 'state | Error | Ignore
 
+type ('res, 'state) call_result =
+  | Reply of ('res * 'state)
+  | Reply_continue of ('res * 'state * cont_req)
+
 module type Impl = sig
   type args
   type state
 
   val init : args -> state init_result
-  val handle_call : 'res. 'res req -> Pid.t -> state -> 'res * state
+
+  val handle_call :
+    'res.
+    'res req -> Pid.t -> state -> ('res, state) call_result
+
+  val handle_continue : cont_req -> state -> state
   val handle_info : Message.t -> state -> unit
 end
 
@@ -39,10 +49,15 @@ let rec loop : type args state. (args, state) impl -> state -> unit =
  fun impl state ->
   let (module I : Impl with type args = args and type state = state) = impl in
   match receive_any () with
-  | Call (pid, ref, req) ->
-      let res, state = I.handle_call req pid state in
-      send pid (Reply (ref, res));
-      loop impl state
+  | Call (pid, ref, req) -> (
+      match I.handle_call req pid state with
+      | Reply (res, state) ->
+          send pid (Reply (ref, res));
+          loop impl state
+      | Reply_continue (res, state, cont_req) ->
+          send pid (Reply (ref, res));
+          let state = I.handle_continue cont_req state in
+          loop impl state)
   | msg ->
       let _res = I.handle_info msg state in
       loop impl state
@@ -65,5 +80,6 @@ let start_link :
 module Default = struct
   let init _args = Ignore
   let handle_call _req _from _state = failwith "unimplemented"
+  let handle_continue _req _state = failwith "unimplemented"
   let handle_info _msg _state = failwith "unimplemented"
 end

--- a/riot/lib/key_value_store.ml
+++ b/riot/lib/key_value_store.ml
@@ -16,11 +16,15 @@ module MakeServer (B : Base) = struct
   let init () = Gen_server.Ok { tbl = Hashtbl.create 0 }
 
   let handle_call :
-      type res. res Gen_server.req -> Pid.t -> state -> res * state =
+      type res.
+      res Gen_server.req ->
+      Pid.t ->
+      state ->
+      (res, state) Gen_server.call_result =
    fun req _from state ->
     match req with
-    | Get k -> (Hashtbl.find_opt state.tbl k, state)
-    | Put (k, v) -> (Hashtbl.replace state.tbl k v, state)
+    | Get k -> Gen_server.Reply (Hashtbl.find_opt state.tbl k, state)
+    | Put (k, v) -> Gen_server.Reply (Hashtbl.replace state.tbl k v, state)
     | _ -> failwith "invalid call"
 end
 

--- a/riot/riot.mli
+++ b/riot/riot.mli
@@ -352,6 +352,8 @@ module Gen_server : sig
       ]}
     *)
 
+  type cont_req = ..
+
   (** [state init_result] is used to initialize a new generic server. *)
   type 'state init_result =
     | Ok of 'state
@@ -359,6 +361,10 @@ module Gen_server : sig
     | Error
         (** use this value to crash the process and notify a supervisor of it *)
     | Ignore  (** use this value to exit the process normally *)
+
+  type ('res, 'state) call_result =
+    | Reply of ('res * 'state)
+    | Reply_continue of ('res * 'state * cont_req)
 
   (** [Impl] is the module type of the generic server base implementations. You
       can use this type when defining new gen servers like this:
@@ -380,7 +386,11 @@ module Gen_server : sig
     type state
 
     val init : args -> state init_result
-    val handle_call : 'res. 'res req -> Pid.t -> state -> 'res * state
+
+    val handle_call :
+      'res. 'res req -> Pid.t -> state -> ('res, state) call_result
+
+    val handle_continue : cont_req -> state -> state
     val handle_info : Message.t -> state -> unit
   end
 

--- a/riot/riot.mli
+++ b/riot/riot.mli
@@ -352,6 +352,7 @@ module Gen_server : sig
       ]}
     *)
 
+  type cast_req = ..
   type cont_req = ..
 
   (** [state init_result] is used to initialize a new generic server. *)
@@ -365,6 +366,8 @@ module Gen_server : sig
   type ('res, 'state) call_result =
     | Reply of ('res * 'state)
     | Reply_continue of ('res * 'state * cont_req)
+
+  type 'state cast_result = No_reply of 'state
 
   (** [Impl] is the module type of the generic server base implementations. You
       can use this type when defining new gen servers like this:
@@ -390,6 +393,7 @@ module Gen_server : sig
     val handle_call :
       'res. 'res req -> Pid.t -> state -> ('res, state) call_result
 
+    val handle_cast : cast_req -> state -> state cast_result
     val handle_continue : cont_req -> state -> state
     val handle_info : Message.t -> state -> unit
   end
@@ -404,6 +408,11 @@ module Gen_server : sig
       This function will block the current process until a response arrives.
 
       TODO(leostera): add ?timeout param
+    *)
+
+  val cast : Pid.t -> cast_req -> unit
+  (** [cast pid req] will send a type-safe request [req] to the generic server behind [pid]
+      and does not wait for a response.
     *)
 
   val start_link :

--- a/test/gen-servers/main.ml
+++ b/test/gen-servers/main.ml
@@ -18,10 +18,12 @@ module Twitch = struct
 
   type _ Gen_server.req +=
     | Is_connected : bool Gen_server.req
+    | Status_value : int Gen_server.req
     | Profile :
         profile_req
         -> (user, [ `Twitch_error of error ]) result Gen_server.req
 
+  type Gen_server.cont_req += Update_status : int -> Gen_server.cont_req
   type args = { verbose : bool }
 
   module Server : Gen_server.Impl with type args = args = struct
@@ -31,15 +33,25 @@ module Twitch = struct
     let init _args = Gen_server.Ok { status = 1 }
 
     let handle_call :
-        type res. res Gen_server.req -> Pid.t -> state -> res * state =
+        type res.
+        res Gen_server.req ->
+        Pid.t ->
+        state ->
+        (res, state) Gen_server.call_result =
      fun req _from state ->
       match req with
-      | Is_connected -> (true, state)
+      | Is_connected -> Gen_server.Reply (true, state)
+      | Status_value -> Gen_server.Reply (state.status, state)
       | Profile _ ->
-          ( Ok { name = "Jonathan Archer"; email = "archer4eva@starfl.it" },
-            state )
+          Gen_server.Reply_continue
+            ( Ok { name = "Jonathan Archer"; email = "archer4eva@starfl.it" },
+              state,
+              Update_status 2 )
 
     let handle_info _msg _state = ()
+
+    let handle_continue cont_req _state =
+      match cont_req with Update_status n -> { status = n }
   end
 
   let start_link ?(verbose = false) () =
@@ -47,13 +59,18 @@ module Twitch = struct
 
   let is_connected pid = Gen_server.call pid Is_connected
   let profile pid ~id = Gen_server.call pid (Profile { id })
+  let status pid = Gen_server.call pid Status_value
 end
 
 let main () =
   let (Ok _) = Logger.start () in
   let (Ok pid) = Twitch.start_link () in
   if Twitch.is_connected pid then Logger.info (fun f -> f "connected to twitch");
+  let status = Twitch.status pid in
+  Logger.info (fun f -> f "Status is %d" status);
   let (Ok user) = Twitch.profile pid ~id:1 in
-  Logger.info (fun f -> f "Welcome, %s!" user.name)
+  Logger.info (fun f -> f "Welcome, %s!" user.name);
+  let status = Twitch.status pid in
+  Logger.info (fun f -> f "Status is %d" status)
 
 let () = Riot.run @@ main

--- a/test/gen-servers/main.ml
+++ b/test/gen-servers/main.ml
@@ -52,6 +52,8 @@ module Twitch = struct
 
     let handle_continue cont_req _state =
       match cont_req with Update_status n -> { status = n }
+
+    let handle_cast _cast_req _state = failwith "unimplemented"
   end
 
   let start_link ?(verbose = false) () =


### PR DESCRIPTION
Closes https://github.com/riot-ml/riot/issues/4

This PR implements the `handle_cast` and `handle_continue` Gen_server methods from Erlang. It also reworks the responses for the `handle_*` methods a bit so that `handle_continue` can be called.

## Request types

You'll see there are two new request types: `cast_req` and `cont_req`. These are separate from the current `req` type used in `handle_call` (which should maybe be renamed to `call_req`. The reason I added these is because `handle_call`, `handle_cast` and `handle_continue` will have different requests that can be sent to them. It doesn't make sense to be able to send a `call` request to `handle_cast` and then having to deal with a potential error/exception if we can prevent it from being valid at all. `handle_cast` and `handle_continue` also don't respond to the client, so they also don't need a `'res` type.

## Result types

I also changed `handle_call` to return a new `call_result` type instead to accommodate for the different ways a Gen_server can respond in Elixir. `Reply ('res * 'state)` is the regular reply it's been using thus far. But to accommodate `handle_continue`, `handle_call` needs to be able to respond with a `{:continue, args}` as well like you can do in Elixir. For this I added a `Reply_continue` as well, which takes the form `('res * 'state * cont_req)`, where `cont_req` will be handled by `handle_continue` after the `'res` has been sent to the client.

Similarly, `cast_result` has a `No_reply`, which is equivalent to the Elixir `{:noreply, state}` response. This can be extended for a `No_reply_continue` option as well, or whatever else GenServers in Elixir allows.

In Elixir (or Erlang I guess), `handle_call` can respond with a `{:noreply, ...}` as well, which assumes that the user manually responded with a `reply(pid, res)` somewhere in the handler. This is useful for when the reply is known already, but additional work needs to be done by the server. I opted not to implement this, as it leads to potential error states where the user perhaps doesn't do a `reply` in the handler, or perhaps does two `reply`s. I also think most behaviours requiring this can be implemented with `handle_continue`, which leaves less room for error.

