### PR TITLE
Fix/logger lifecycle

### DIFF
--- a/riot/lib/logger/logger.ml
+++ b/riot/lib/logger/logger.ml
@@ -3,6 +3,7 @@ module Log = Riot_runtime.Log
 open Global
 
 type opts = { print_source : bool; print_time : bool; color_output : bool }
+type config = { opts : opts; started_by : Riot_runtime.Core.Pid.t }
 
 type ('a, 'b) logger_format =
   (('a, Format.formatter, unit, 'b) format4 -> 'a) -> 'b

--- a/riot/lib/ssl.ml
+++ b/riot/lib/ssl.ml
@@ -100,28 +100,28 @@ module Tls_unix = struct
     let handle tls cs =
       match Tls.Engine.handle_tls tls cs with
       | Ok (state', eof, `Response resp, `Data data) ->
-         trace (fun f -> f "tls.read_react->ok");
-         let state' =
-           match eof with
-           | Some `Eof -> `Eof
-           | _ -> inject_state state' t.state
-         in
-         t.state <- state';
-         Option.iter (try_write_t t) resp;
-         data
+          trace (fun f -> f "tls.read_react->ok");
+          let state' =
+            match eof with
+            | Some `Eof -> `Eof
+            | _ -> inject_state state' t.state
+          in
+          t.state <- state';
+          Option.iter (try_write_t t) resp;
+          data
       | Error (fail, `Response resp) ->
-         let state' =
-           match fail with
-           | `Alert a ->
-              trace (fun f -> f "tls.read_react->alert");
-              `Error (Tls_alert a)
-           | f ->
-              trace (fun f -> f "tls.read_react->error");
-              `Error (Tls_failure f)
-         in
-         t.state <- state';
-         write_t t resp;
-         read_react t
+          let state' =
+            match fail with
+            | `Alert a ->
+                trace (fun f -> f "tls.read_react->alert");
+                `Error (Tls_alert a)
+            | f ->
+                trace (fun f -> f "tls.read_react->error");
+                `Error (Tls_failure f)
+          in
+          t.state <- state';
+          write_t t resp;
+          read_react t
     in
 
     match t.state with


### PR DESCRIPTION
This change makes the Logger application startup process _block_ until
the logger is ready to take in requests. This means applications relying
on the logger will take a tiny bit longer to boot, but we can guarantee
that the log requests will not be dropped because of process spawn
order.

Close https://github.com/riot-ml/riot/issues/82